### PR TITLE
Delete twin

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ frontends for csv2json (respectively blob triggered and http triggered).
 
 The injector is triggered by uploading a CSV file to an azure storage
 container and expects the following columns for twins:
- - `$metadata.$model`: The model id of the twin,
- - `$id`: The id of the twin,
+ - `$metadata.$model`: The model id of the twin;
+ - `$id`: The id of the twin;
+ - `$entityDelete`: If true, the twin is deleted, if false the twin is upserted;
  - one column for each property or telemetry, with complex properties
    flattened with dot-spearated headers.
 for instance given the following twin model:
@@ -78,14 +79,14 @@ for instance given the following twin model:
 
 You may inject twins matching this model using the following CSV file:
 
-| `"$metadata.$model"`          | `"$id"`        | `"color"` | `"position.x"` | `"position.y"` |
-| ----------------------------- | -------------- | --------- | -------------- | -------------- |
-| `dtmi:com.example:flagpole;1` | `"first_pole"` | `"red"`   | `25.3`         | `42.0`         |
+| `"$metadata.$model"`          | `"$id"`        | `"$entityDelete"` | `"color"` | `"position.x"` | `"position.y"` |
+| ----------------------------- | -------------- | ----------------- | --------- | -------------- | -------------- |
+| `dtmi:com.example:flagpole;1` | `"first_pole"` | `"false"`         | `"red"`   | `25.3`         | `42.0`         |
 
 Inserting relationships with `dt-injector` requires the following columns:
 
-| `"$sourceId"` | `"$targetId"` | `"$relationshipId"` | `"$relationshipName"` | `"property1"` | `"property..."` |
-| ------------- | ------------- | ------------------- | --------------------- | ------------- | --------------- |
+| `"$sourceId"` | `"$targetId"` | `"$relationshipId"` | `"$relationshipName"` | `"$relationshipDelete"` | `"property1"` | `"property..."` |
+| ------------- | ------------- | ------------------- | --------------------- | ----------------------- | ------------- | --------------- |
 
 # Configuration
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The injector is triggered by uploading a CSV file to an azure storage
 container and expects the following columns for twins:
  - `$metadata.$model`: The model id of the twin;
  - `$id`: The id of the twin;
- - `$entityDelete`: If true, the twin is deleted, if false the twin is upserted;
+ - `$entityDelete`: If true, the twin is deleted with all its in & out relationships, if false the twin is upserted; Optional. Default: false
  - one column for each property or telemetry, with complex properties
    flattened with dot-spearated headers.
 for instance given the following twin model:

--- a/doUpsert/index.js
+++ b/doUpsert/index.js
@@ -27,9 +27,10 @@ module.exports = async function(context, jsonItem) {
       new DefaultAzureCredential());
   const jsonString = JSON.stringify(jsonItem);
   context.log.verbose(`Json item: ${jsonString}`);
-  
+
   if ('$relationshipId' in jsonItem) {
-    if (jsonItem.relationship.$relationshipDelete === true) { // relationship must be deleted
+    if (jsonItem.relationship.$relationshipDelete === true) {
+      // relationship must be deleted
       context.log.verbose(`deleting relationship ${jsonItem.$relationshipId}`);
       await (async () => {
         context.log.verbose('waiting 100ms');
@@ -66,16 +67,16 @@ module.exports = async function(context, jsonItem) {
   } else if ('$id' in jsonItem) {
     if (jsonItem.$entityDelete === true) { // twin must be deleted
       // list all twin relationships
-      let rels = []
+      const rels = [];
       // outgoing relationships
-      let out = digitalTwin.listRelationships(jsonItem.$id);
+      const out = digitalTwin.listRelationships(jsonItem.$id);
       for await (const rel of out) {
-        rels.push([rel.$sourceId, rel.$relationshipId])
+        rels.push([rel.$sourceId, rel.$relationshipId]);
       }
       // incoming relationships
-      let inc = digitalTwin.listIncomingRelationships(jsonItem.$id);
+      const inc = digitalTwin.listIncomingRelationships(jsonItem.$id);
       for await (const rel of inc) {
-        rels.push([rel.sourceId, rel.relationshipId])
+        rels.push([rel.sourceId, rel.relationshipId]);
       }
       // delete all twin relationships
       for (const tbd of rels) {

--- a/doUpsert/index.js
+++ b/doUpsert/index.js
@@ -29,25 +29,7 @@ module.exports = async function(context, jsonItem) {
   context.log.verbose(`Json item: ${jsonString}`);
   
   if ('$relationshipId' in jsonItem) {
-<<<<<<< Updated upstream
-    context.log.verbose(`upserting relationship ${jsonItem.$relationshipId}`);
-    await (async () => {
-      context.log.verbose('waiting 100ms');
-      sleep(100);
-      context.log.verbose('calling ADT relationship API');
-      await digitalTwin.upsertRelationship(
-          jsonItem.$sourceId,
-          jsonItem.$relationshipId,
-          jsonItem.relationship)
-          .catch((e) => {
-            context.log.error(`relationship ${jsonItem.$relationshipId}
-              on source ${jsonItem.$sourceId} insertion failed: `, e);
-            const err = `failed relationship: ${jsonString}`;
-            throw err;
-          });
-    })();
-=======
-    if (jsonItem.$relationshipDelete === true) { // relationship must be deleted
+    if (jsonItem.relationship.$relationshipDelete === true) { // relationship must be deleted
       context.log.verbose(`deleting relationship ${jsonItem.$relationshipId}`);
       await (async () => {
         context.log.verbose('waiting 100ms');
@@ -71,7 +53,8 @@ module.exports = async function(context, jsonItem) {
         context.log.verbose('calling ADT relationship API');
         await digitalTwin.upsertRelationship(
             jsonItem.$sourceId,
-            jsonItem.$relationshipId, jsonItem)
+            jsonItem.$relationshipId,
+            jsonItem.relationship)
             .catch((e) => {
               context.log.error(`relationship ${jsonItem.$relationshipId}
                 on source ${jsonItem.$sourceId} insertion failed: `, e);
@@ -80,7 +63,6 @@ module.exports = async function(context, jsonItem) {
             });
       })();
     }
->>>>>>> Stashed changes
   } else if ('$id' in jsonItem) {
     if (jsonItem.$entityDelete === true) { // twin must be deleted
       // list all twin relationships


### PR DESCRIPTION
Closes #8 - Add mandatory columns to twin and relationship upsert files (respectively $entityDelete and $relationshipDelete). Both columns expect a boolean value: if true, the corresponding twin or relationship is deleted (it must exist); if false, it is upserted as usual.
All incoming and outgoing relationships of a given twin are deleted before deleting the twin itself.