### PR TITLE
Update twin

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,15 +79,20 @@ for instance given the following twin model:
 
 You may inject twins matching this model using the following CSV file:
 
+| `"$metadata.$model"`          | `"$id"`        | `"$entityDelete"` | `"color"` | `"position"`                   |
+| ----------------------------- | -------------- | ----------------- | --------- | ------------------------------ |
+| `dtmi:com.example:flagpole;1` | `"first_pole"` | `"false"`         | `"red"`   | `"{""x"": 25.3, ""y"": 42.0}"` |
+
+Alternatively, the values `"position/x"` and `"position/y"` can be injected
+individually using their complete path as a column name:
+
 | `"$metadata.$model"`          | `"$id"`        | `"$entityDelete"` | `"color"` | `"position/x"` | `"position/y"` |
 | ----------------------------- | -------------- | ----------------- | --------- | -------------- | -------------- |
 | `dtmi:com.example:flagpole;1` | `"first_pole"` | `"false"`         | `"red"`   | `25.3`         | `42.0`         |
 
-Alternatively, the values `"position/x"` and `"position/y"` can be injected as a single nested structure:
-
-| `"$metadata.$model"`          | `"$id"`        | `"$entityDelete"` | `"color"` | `"position"`                   |
-| ----------------------------- | -------------- | ----------------- | --------- | ------------------------------ |
-| `dtmi:com.example:flagpole;1` | `"first_pole"` | `"false"`         | `"red"`   | `"{""x"": 25.3, ""y"": 42.0}"` |
+Note: this alternative syntax **does not work if target property is empty**.
+For instance, the example above will fail if the property `"position"` is
+empty.
 
 Inserting relationships with `dt-injector` requires the following columns:
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,15 @@ for instance given the following twin model:
 
 You may inject twins matching this model using the following CSV file:
 
-| `"$metadata.$model"`          | `"$id"`        | `"$entityDelete"` | `"color"` | `"position.x"` | `"position.y"` |
+| `"$metadata.$model"`          | `"$id"`        | `"$entityDelete"` | `"color"` | `"position/x"` | `"position/y"` |
 | ----------------------------- | -------------- | ----------------- | --------- | -------------- | -------------- |
 | `dtmi:com.example:flagpole;1` | `"first_pole"` | `"false"`         | `"red"`   | `25.3`         | `42.0`         |
+
+Alternatively, the values `"position/x"` and `"position/y"` can be injected as a single nested structure:
+
+| `"$metadata.$model"`          | `"$id"`        | `"$entityDelete"` | `"color"` | `"position"`                   |
+| ----------------------------- | -------------- | ----------------- | --------- | ------------------------------ |
+| `dtmi:com.example:flagpole;1` | `"first_pole"` | `"false"`         | `"red"`   | `"{""x"": 25.3, ""y"": 42.0}"` |
 
 Inserting relationships with `dt-injector` requires the following columns:
 

--- a/doUpsert/index.js
+++ b/doUpsert/index.js
@@ -15,7 +15,7 @@
 
 const {DigitalTwinsClient} = require('@azure/digital-twins-core');
 const {DefaultAzureCredential} = require('@azure/identity');
-const {RestError} = require('@azure/storage-queue');
+const {RestError} = require('@azure/core-http');
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 


### PR DESCRIPTION
Closes #9 - Added twin and relationship update logic by using JSON patch syntax.

* When trying to inject an already existing twin, its properties are updated instead of upserting the twin.
* When trying to inject an already existing relationship, its properties are updated instead of upserting the relationship.